### PR TITLE
Avoid creating the nilearn_cache folder when using nilearn maskers

### DIFF
--- a/connPFM/connectivity/ev.py
+++ b/connPFM/connectivity/ev.py
@@ -54,7 +54,6 @@ def event_detection(data_file, atlas, surrprefix="", sursufix="", nsur=100, segm
     masker = NiftiLabelsMasker(
         labels_img=atlas,
         standardize=False,
-        memory="",
         strategy="mean",
     )
 

--- a/connPFM/connectivity/ev.py
+++ b/connPFM/connectivity/ev.py
@@ -54,7 +54,7 @@ def event_detection(data_file, atlas, surrprefix="", sursufix="", nsur=100, segm
     masker = NiftiLabelsMasker(
         labels_img=atlas,
         standardize=False,
-        memory="nilearn_cache",
+        memory="",
         strategy="mean",
     )
 

--- a/connPFM/debiasing/debiasing.py
+++ b/connPFM/debiasing/debiasing.py
@@ -19,7 +19,6 @@ def debiasing(data_file, mask, mtx, tr, out_dir, history_str):
     masker = NiftiLabelsMasker(
         labels_img=mask,
         standardize=False,
-        memory="",
         strategy="mean",
     )
 

--- a/connPFM/debiasing/debiasing.py
+++ b/connPFM/debiasing/debiasing.py
@@ -19,7 +19,7 @@ def debiasing(data_file, mask, mtx, tr, out_dir, history_str):
     masker = NiftiLabelsMasker(
         labels_img=mask,
         standardize=False,
-        memory="nilearn_cache",
+        memory="",
         strategy="mean",
     )
 

--- a/connPFM/deconvolution/roiPFM.py
+++ b/connPFM/deconvolution/roiPFM.py
@@ -38,7 +38,7 @@ def roiPFM(
     LGR.info("Masking data...")
     atlas_old = atlas
     atlas = atlas_mod.transform(atlas, data, dir)
-    masker = NiftiLabelsMasker(labels_img=atlas, standardize="psc", memory="", strategy="mean")
+    masker = NiftiLabelsMasker(labels_img=atlas, standardize="psc", strategy="mean")
     data_masked = masker.fit_transform(data)
     LGR.info("Data masked.")
 

--- a/connPFM/deconvolution/roiPFM.py
+++ b/connPFM/deconvolution/roiPFM.py
@@ -38,9 +38,7 @@ def roiPFM(
     LGR.info("Masking data...")
     atlas_old = atlas
     atlas = atlas_mod.transform(atlas, data, dir)
-    masker = NiftiLabelsMasker(
-        labels_img=atlas, standardize="psc", memory="", strategy="mean"
-    )
+    masker = NiftiLabelsMasker(labels_img=atlas, standardize="psc", memory="", strategy="mean")
     data_masked = masker.fit_transform(data)
     LGR.info("Data masked.")
 

--- a/connPFM/deconvolution/roiPFM.py
+++ b/connPFM/deconvolution/roiPFM.py
@@ -39,7 +39,7 @@ def roiPFM(
     atlas_old = atlas
     atlas = atlas_mod.transform(atlas, data, dir)
     masker = NiftiLabelsMasker(
-        labels_img=atlas, standardize="psc", memory="nilearn_cache", strategy="mean"
+        labels_img=atlas, standardize="psc", memory="", strategy="mean"
     )
     data_masked = masker.fit_transform(data)
     LGR.info("Data masked.")

--- a/connPFM/tests/test_ev.py
+++ b/connPFM/tests/test_ev.py
@@ -10,7 +10,6 @@ def test_calculate_ets(ets_auc_original_file, AUC_file, atlas_file):
     masker = NiftiLabelsMasker(
         labels_img=atlas_file,
         standardize=False,
-        memory="",
         strategy="mean",
         resampling_target=None,
     )
@@ -25,7 +24,6 @@ def test_rss_surr(AUC_file, atlas_file, surr_dir, rssr_auc_file):
     masker = NiftiLabelsMasker(
         labels_img=atlas_file,
         standardize=False,
-        memory="",
         strategy="mean",
     )
 

--- a/connPFM/tests/test_ev.py
+++ b/connPFM/tests/test_ev.py
@@ -10,7 +10,7 @@ def test_calculate_ets(ets_auc_original_file, AUC_file, atlas_file):
     masker = NiftiLabelsMasker(
         labels_img=atlas_file,
         standardize=False,
-        memory="nilearn_cache",
+        memory="",
         strategy="mean",
         resampling_target=None,
     )
@@ -25,7 +25,7 @@ def test_rss_surr(AUC_file, atlas_file, surr_dir, rssr_auc_file):
     masker = NiftiLabelsMasker(
         labels_img=atlas_file,
         standardize=False,
-        memory="nilearn_cache",
+        memory="",
         strategy="mean",
     )
 

--- a/connPFM/utils/surrogate_generator.py
+++ b/connPFM/utils/surrogate_generator.py
@@ -36,7 +36,7 @@ def generate_surrogate(data, atlas, output):
     # Mask data
     LGR.info("Masking data...")
     surrogate_masker = NiftiLabelsMasker(
-        labels_img=atlas, standardize="psc", memory="nilearn_cache", strategy="mean"
+        labels_img=atlas, standardize="psc", memory="", strategy="mean"
     )
     data_masked = surrogate_masker.fit_transform(data)
     LGR.info("Data masked.")

--- a/connPFM/utils/surrogate_generator.py
+++ b/connPFM/utils/surrogate_generator.py
@@ -36,7 +36,7 @@ def generate_surrogate(data, atlas, output):
     # Mask data
     LGR.info("Masking data...")
     surrogate_masker = NiftiLabelsMasker(
-        labels_img=atlas, standardize="psc", memory="", strategy="mean"
+        labels_img=atlas, standardize="psc", strategy="mean"
     )
     data_masked = surrogate_masker.fit_transform(data)
     LGR.info("Data masked.")

--- a/connPFM/utils/surrogate_generator.py
+++ b/connPFM/utils/surrogate_generator.py
@@ -35,9 +35,7 @@ def generate_surrogate(data, atlas, output):
     """
     # Mask data
     LGR.info("Masking data...")
-    surrogate_masker = NiftiLabelsMasker(
-        labels_img=atlas, standardize="psc", strategy="mean"
-    )
+    surrogate_masker = NiftiLabelsMasker(labels_img=atlas, standardize="psc", strategy="mean")
     data_masked = surrogate_masker.fit_transform(data)
     LGR.info("Data masked.")
 

--- a/ismrm2022/stability_pfm.py
+++ b/ismrm2022/stability_pfm.py
@@ -35,7 +35,6 @@ def main():
     masker = NiftiLabelsMasker(
         labels_img=atlas,
         standardize=False,
-        memory="",
         strategy="mean",
     )
 

--- a/ismrm2022/stability_pfm.py
+++ b/ismrm2022/stability_pfm.py
@@ -35,7 +35,7 @@ def main():
     masker = NiftiLabelsMasker(
         labels_img=atlas,
         standardize=False,
-        memory="nilearn_cache",
+        memory="",
         strategy="mean",
     )
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for connPFM.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Now the memory option in the masker is not used
-
