### PR TITLE
subsample_idx has a larger size due to multiple echoes

### DIFF
--- a/connPFM/deconvolution/stability_lars.py
+++ b/connPFM/deconvolution/stability_lars.py
@@ -20,20 +20,6 @@ class StabilityLars:
             subsample_idx = np.sort(
                 np.random.choice(range(self.nscans), int(0.6 * self.nscans), 0)
             )  # 60% of timepoints are kept
-            if self.nTE > 1:
-                for i in range(self.nTE - 1):
-                    subsample_idx = np.concatenate(
-                        (
-                            subsample_idx,
-                            np.sort(
-                                np.random.choice(
-                                    range((i + 1) * self.nscans, (i + 2) * self.nscans),
-                                    int(0.6 * self.nscans),
-                                    0,
-                                )
-                            ),
-                        )
-                    )
         elif self.mode > 1:  # same time points are selected across echoes
             subsample_idx = np.sort(
                 np.random.choice(range(self.nscans), int(0.6 * self.nscans), 0)

--- a/connPFM/deconvolution/stability_lars.py
+++ b/connPFM/deconvolution/stability_lars.py
@@ -1,5 +1,4 @@
 import os
-from curses import echo
 
 import numpy as np
 from sklearn.linear_model import lars_path

--- a/connPFM/deconvolution/stability_lars.py
+++ b/connPFM/deconvolution/stability_lars.py
@@ -1,5 +1,5 @@
-from curses import echo
 import os
+from curses import echo
 
 import numpy as np
 from sklearn.linear_model import lars_path
@@ -19,7 +19,7 @@ class StabilityLars:
         # Subsampling for Stability Selection
         if self.mode == 1:  # different time points are selected across echoes
             if self.nTE > 1:
-                echo_scans=self.scans/self.nTE
+                echo_scans = self.scans / self.nTE
                 subsample_idx = np.sort(
                     np.random.choice(range(echo_scans), int(0.6 * echo_scans), 0)
                 )
@@ -38,8 +38,8 @@ class StabilityLars:
                     )
             else:
                 subsample_idx = np.sort(
-                np.random.choice(range(self.nscans), int(0.6 * self.nscans), 0)
-            )  # 60% of timepoints are kept
+                    np.random.choice(range(self.nscans), int(0.6 * self.nscans), 0)
+                )  # 60% of timepoints are kept
         elif self.mode > 1:  # same time points are selected across echoes
             subsample_idx = np.sort(
                 np.random.choice(range(self.nscans), int(0.6 * self.nscans), 0)

--- a/connPFM/deconvolution/stability_lars.py
+++ b/connPFM/deconvolution/stability_lars.py
@@ -17,7 +17,7 @@ class StabilityLars:
             np.random.seed(200)
         # Subsampling for Stability Selection
         if self.mode == 1:  # different time points are selected across echoes
-            echo_scans = self.scans / self.nTE
+            echo_scans = self.nscans / self.nTE
             subsample_idx = np.sort(np.random.choice(range(echo_scans), int(0.6 * echo_scans), 0))
             for i in range(self.nTE - 1):
                 subsample_idx = np.concatenate(

--- a/connPFM/deconvolution/stability_lars.py
+++ b/connPFM/deconvolution/stability_lars.py
@@ -18,9 +18,7 @@ class StabilityLars:
         # Subsampling for Stability Selection
         if self.mode == 1:  # different time points are selected across echoes
             echo_scans = self.scans / self.nTE
-            subsample_idx = np.sort(
-                np.random.choice(range(echo_scans), int(0.6 * echo_scans), 0)
-            )
+            subsample_idx = np.sort(np.random.choice(range(echo_scans), int(0.6 * echo_scans), 0))
             for i in range(self.nTE - 1):
                 subsample_idx = np.concatenate(
                     (

--- a/connPFM/deconvolution/stability_lars.py
+++ b/connPFM/deconvolution/stability_lars.py
@@ -17,7 +17,7 @@ class StabilityLars:
             np.random.seed(200)
         # Subsampling for Stability Selection
         if self.mode == 1:  # different time points are selected across echoes
-            echo_scans = self.nscans / self.nTE
+            echo_scans = int(self.nscans / self.nTE)
             subsample_idx = np.sort(np.random.choice(range(echo_scans), int(0.6 * echo_scans), 0))
             for i in range(self.nTE - 1):
                 subsample_idx = np.concatenate(

--- a/connPFM/deconvolution/stability_lars.py
+++ b/connPFM/deconvolution/stability_lars.py
@@ -17,28 +17,24 @@ class StabilityLars:
             np.random.seed(200)
         # Subsampling for Stability Selection
         if self.mode == 1:  # different time points are selected across echoes
-            if self.nTE > 1:
-                echo_scans = self.scans / self.nTE
-                subsample_idx = np.sort(
-                    np.random.choice(range(echo_scans), int(0.6 * echo_scans), 0)
-                )
-                for i in range(self.nTE - 1):
-                    subsample_idx = np.concatenate(
-                        (
-                            subsample_idx,
-                            np.sort(
-                                np.random.choice(
-                                    range((i + 1) * echo_scans, (i + 2) * echo_scans),
-                                    int(0.6 * echo_scans),
-                                    0,
-                                )
-                            ),
-                        )
+            echo_scans = self.scans / self.nTE
+            subsample_idx = np.sort(
+                np.random.choice(range(echo_scans), int(0.6 * echo_scans), 0)
+            )
+            for i in range(self.nTE - 1):
+                subsample_idx = np.concatenate(
+                    (
+                        subsample_idx,
+                        np.sort(
+                            np.random.choice(
+                                range((i + 1) * echo_scans, (i + 2) * echo_scans),
+                                int(0.6 * echo_scans),
+                                0,
+                            )
+                        ),
                     )
-            else:
-                subsample_idx = np.sort(
-                    np.random.choice(range(self.nscans), int(0.6 * self.nscans), 0)
-                )  # 60% of timepoints are kept
+                )
+        # 60% of timepoints are kept
         elif self.mode > 1:  # same time points are selected across echoes
             subsample_idx = np.sort(
                 np.random.choice(range(self.nscans), int(0.6 * self.nscans), 0)

--- a/connPFM/deconvolution/stability_lars.py
+++ b/connPFM/deconvolution/stability_lars.py
@@ -1,3 +1,4 @@
+from curses import echo
 import os
 
 import numpy as np
@@ -17,7 +18,26 @@ class StabilityLars:
             np.random.seed(200)
         # Subsampling for Stability Selection
         if self.mode == 1:  # different time points are selected across echoes
-            subsample_idx = np.sort(
+            if self.nTE > 1:
+                echo_scans=self.scans/self.nTE
+                subsample_idx = np.sort(
+                    np.random.choice(range(echo_scans), int(0.6 * echo_scans), 0)
+                )
+                for i in range(self.nTE - 1):
+                    subsample_idx = np.concatenate(
+                        (
+                            subsample_idx,
+                            np.sort(
+                                np.random.choice(
+                                    range((i + 1) * echo_scans, (i + 2) * echo_scans),
+                                    int(0.6 * echo_scans),
+                                    0,
+                                )
+                            ),
+                        )
+                    )
+            else:
+                subsample_idx = np.sort(
                 np.random.choice(range(self.nscans), int(0.6 * self.nscans), 0)
             )  # 60% of timepoints are kept
         elif self.mode > 1:  # same time points are selected across echoes


### PR DESCRIPTION
<!---
This is a suggested pull request template for connPFM.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
For some reason the method `_subsampling` was checking if the data was multiecho and based on that  it was creating a 
`subsample_idx` vector that was `nscans` * `nTE`. However the recent changes of the code make that X.shape[1] which defines nscans inside `stability_lars.py` is already `nscans`*`nTE`. This results in a `subsample_idx` vector of shape `nscans`  * `nTE` * `nTE` which makes the code fail
<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add new variable `echo_scans` that shows the number of echoes by scans and use it in the if condition for `nTE>1`
-
