### PR TITLE
Move connPFM_slim container to OSF

### DIFF
--- a/connPFM/deconvolution/compute_slars.sh
+++ b/connPFM/deconvolution/compute_slars.sh
@@ -22,5 +22,5 @@ then
 else
     echo ${INPUT_ARGS[0]}
     cd /bcbl/home/public/PARK_VFERRER
-    singularity exec --bind $PWD $PWD/connpfm_slim.simg python -u /connPFM/deconvolution/compute_slars.py $INPUT_ARGS
+    singularity exec --bind $PWD /connPFM/deconvolution/connpfm_slim.simg python -u /connPFM/deconvolution/compute_slars.py $INPUT_ARGS
 fi

--- a/connPFM/deconvolution/compute_slars.sh
+++ b/connPFM/deconvolution/compute_slars.sh
@@ -22,5 +22,5 @@ then
 else
     echo ${INPUT_ARGS[0]}
     cd /bcbl/home/public/PARK_VFERRER
-    singularity exec --bind $PWD /connPFM/deconvolution/connpfm_slim.simg python -u /connPFM/deconvolution/compute_slars.py $INPUT_ARGS
+    singularity exec --bind $WDIR $FILE_DIR/connpfm_slim.simg python -u /connPFM/deconvolution/compute_slars.py $INPUT_ARGS
 fi

--- a/connPFM/deconvolution/roiPFM.py
+++ b/connPFM/deconvolution/roiPFM.py
@@ -1,12 +1,11 @@
 import logging
 import os
-import subprocess
 from shutil import which
 
 from connPFM.deconvolution.stability_lars_caller import run_stability_lars
+from connPFM.tests.conftest import fetch_file
 from connPFM.utils import hrf_generator, surrogate_generator
 from connPFM.utils.io import load_data, save_img
-from connPFM.tests.conftest import fetch_file
 
 LGR = logging.getLogger(__name__)
 
@@ -62,7 +61,7 @@ def roiPFM(
 
     LGR.info("Running stability selection on original data...")
     if which("singularity") is not None:
-        fetch_file('n7tzh',os.path.dirname(os.path.realpath(__file__)), 'connpfm_slim.simg')
+        fetch_file("n7tzh", os.path.dirname(os.path.realpath(__file__)), "connpfm_slim.simg")
     auc = run_stability_lars(
         data=data_masked,
         hrf=hrf,

--- a/connPFM/deconvolution/roiPFM.py
+++ b/connPFM/deconvolution/roiPFM.py
@@ -6,6 +6,7 @@ from shutil import which
 from connPFM.deconvolution.stability_lars_caller import run_stability_lars
 from connPFM.utils import hrf_generator, surrogate_generator
 from connPFM.utils.io import load_data, save_img
+from connPFM.tests.conftest import fetch_file
 
 LGR = logging.getLogger(__name__)
 
@@ -61,11 +62,7 @@ def roiPFM(
 
     LGR.info("Running stability selection on original data...")
     if which("singularity") is not None:
-        cmd = (
-            "singularity pull --force "
-            "$HOME/connpfm_slim.simg library://vferrer/default/connpfm_slim:latest"
-        )
-        subprocess.call(cmd, shell=True)
+        fetch_file('n7tzh',os.path.dirname(os.path.realpath(__file__)), 'connpfm_slim.simg')
     auc = run_stability_lars(
         data=data_masked,
         hrf=hrf,

--- a/connPFM/deconvolution/stability_lars_caller.py
+++ b/connPFM/deconvolution/stability_lars_caller.py
@@ -110,6 +110,8 @@ def run_stability_lars(data, hrf, temp, jobs, username, niter, maxiterfactor):
                 + ' -v INPUT_ARGS="'
                 + input_parameters
                 + '"'
+                + f' -v FILE_DIR="{os.path.dirname(os.path.abspath(__file__))}"'
+                + f' -v WDIR="{os.path.dirname(os.path.abspath(data_filename))}"'
                 + f" {os.path.dirname(os.path.abspath(__file__))}/compute_slars.sh ",
                 shell=True,
             )


### PR DESCRIPTION


<!---
This is a suggested pull request template for connPFM.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #71  .
Singularity hub no longer exists therefore we are moving the connPFM_slim container to OSF
<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Now the container is downloaded from OSF to the connPFM/deconvolution folder
- singularity --bind points directly to the temporal folder so the container can see the data
