### PR TITLE
Make the conversion to integrer before multipying by the nTE

### DIFF
--- a/connPFM/deconvolution/stability_lars.py
+++ b/connPFM/deconvolution/stability_lars.py
@@ -43,7 +43,6 @@ class StabilityLars:
     def stability_lars(self, X, Y):
 
         self.nscans = X.shape[1]
-        te_concat = self.nscans * self.nTE
         nvoxels = Y.shape[1]
         nlambdas = self.nscans + 1
 
@@ -52,7 +51,7 @@ class StabilityLars:
         for vox_idx in range(nvoxels):
             lambdas = np.zeros((self.nsurrogates, nlambdas), dtype=np.float32)
             coef_path = np.zeros((self.nsurrogates, self.nscans, nlambdas), dtype=np.float32)
-            self.sur_idxs = np.zeros((self.nsurrogates, int(0.6 * te_concat)))
+            self.sur_idxs = np.zeros((self.nsurrogates, int(0.6 * self.nscans)*self.nTE))
             for surrogate_idx in range(self.nsurrogates):
 
                 idxs = self._subsampling()

--- a/connPFM/deconvolution/stability_lars.py
+++ b/connPFM/deconvolution/stability_lars.py
@@ -51,7 +51,7 @@ class StabilityLars:
         for vox_idx in range(nvoxels):
             lambdas = np.zeros((self.nsurrogates, nlambdas), dtype=np.float32)
             coef_path = np.zeros((self.nsurrogates, self.nscans, nlambdas), dtype=np.float32)
-            self.sur_idxs = np.zeros((self.nsurrogates, int(0.6 * self.nscans)*self.nTE))
+            self.sur_idxs = np.zeros((self.nsurrogates, int(0.6 * self.nscans) * self.nTE))
             for surrogate_idx in range(self.nsurrogates):
 
                 idxs = self._subsampling()


### PR DESCRIPTION
<!---
This is a suggested pull request template for connPFM.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Now when defining sur_idxs first we round `0.6*nscans` to integer then multiply by the number of echoes
-
