### PR TITLE
Correct HRF shape in debias  and output names for multiecho

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ jobs:
     working_directory: /tmp/src/connPFM
     docker:
       - image: connpfm/afni_miniconda
+    resource_class: large
     steps:
       - attach_workspace:  # get connPFM
           at: /tmp
@@ -98,7 +99,7 @@ jobs:
             cp -r /opt/conda/envs/py<< parameters.PYTHON >>_env /opt/miniconda-latest/envs/py<< parameters.PYTHON >>_env
             source activate py<< parameters.PYTHON >>_env
             make integration
-          no_output_timeout: 20m
+          no_output_timeout: 30m
       - codecov/upload:
           file: /tmp/src/connPFM/coverage.xml
 

--- a/connPFM/debiasing/debiasing.py
+++ b/connPFM/debiasing/debiasing.py
@@ -46,7 +46,7 @@ def debiasing(data_file, mask, te, mtx, tr, out_dir, prefix, groups, groups_dist
     hrf = HRFMatrix(
         TR=tr,
         TE=te,
-        nscans=int(data.shape[0]/len(te)),
+        nscans=int(data.shape[0] / len(te)),
         r2only=True,
         is_afni=True,
     )

--- a/connPFM/debiasing/debiasing.py
+++ b/connPFM/debiasing/debiasing.py
@@ -46,12 +46,11 @@ def debiasing(data_file, mask, te, mtx, tr, out_dir, prefix, groups, groups_dist
     hrf = HRFMatrix(
         TR=tr,
         TE=te,
-        nscans=data.shape[0],
+        nscans=int(data.shape[0]/len(te)),
         r2only=True,
         is_afni=True,
     )
     hrf.generate_hrf()
-
     # Perform debiasing
     deb_output = debiasing_spike(hrf, data, ets_mask, groups=groups, group_dist=groups_dist)
     beta = deb_output["beta"]
@@ -70,13 +69,13 @@ def debiasing(data_file, mask, te, mtx, tr, out_dir, prefix, groups, groups_dist
     else:
         for echo_idx in range(len(te)):
             # The number of scans is the shape[1] of the hrf matrix
-            nscans = hrf.shape[1]
+            nscans = hrf.hrf_norm.shape[1]
 
             #  Get the betafitts of the current echo from the betafitts matrix
             echo_fitt = fitt[echo_idx * nscans : (echo_idx + 1) * nscans, :]
 
             #  Save the betafitts of the current echo
-            fitt_file = join(out_dir, f"{prefix}_fitt_ETS_echo-1{echo_idx}.nii.gz")
+            fitt_file = join(out_dir, f"{prefix}_fitt_ETS_echo-{echo_idx}.nii.gz")
             io.save_img(echo_fitt, fitt_file, masker, history_str)
 
     LGR.info("Debiasing finished and files saved.")

--- a/connPFM/debiasing/debiasing_functions.py
+++ b/connPFM/debiasing/debiasing_functions.py
@@ -9,7 +9,7 @@ LGR = logging.getLogger(__name__)
 
 def group_hrf(hrf, non_zero_idxs, group_dist=3):
 
-    temp = np.zeros(hrf.shape[1])
+    temp = np.zeros(hrf.shape[0])
     hrf_out = np.zeros(hrf.shape)
     non_zeros_flipped = np.flip(non_zero_idxs)
     new_idxs = []


### PR DESCRIPTION
<!---
This is a suggested pull request template for connPFM.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Adjust the code so that `nscans` is divided by the number of echos for hrf definition
- Adjust multiecho naming from `f"{prefix}_fitt_ETS_echo-1{echo_idx}.nii.gz"` to `f"{prefix}_fitt_ETS_echo-{echo_idx}.nii.gz"`
