### PR TITLE
Jobs variable is a list when used in the console

### DIFF
--- a/connPFM/cli/connPFM.py
+++ b/connPFM/cli/connPFM.py
@@ -89,7 +89,7 @@ def _get_parser():
         dest="jobs",
         type=int,
         help=("Number of jobs to run in parallel (default = 1)."),
-        default=1,
+        default=[1],
         nargs=1,
     )
     optoptions.add_argument(

--- a/connPFM/connPFM.py
+++ b/connPFM/connPFM.py
@@ -88,7 +88,7 @@ def _main(argv=None):
             history_str,
             options["peak_detection"][0],
             afni_text=options["peaks_path"],
-            jobs=options["jobs"],
+            jobs=options["jobs"][0],
         )
         LGR.info("Perform debiasing based on edge-time matrix.")
         debiasing(
@@ -134,7 +134,7 @@ def _main(argv=None):
             history_str=history_str,
             peak_detection=options["peak_detection"][0],
             afni_text=options["peaks_path"],
-            jobs=options["jobs"],
+            jobs=options["jobs"][0],
         )
     elif selected_workflow == "debias":
         ets_auc_denoised = loadtxt(options["matrix"][0])

--- a/connPFM/tests/test_integration.py
+++ b/connPFM/tests/test_integration.py
@@ -12,7 +12,7 @@ def test_integration_pfm(testpath, bold_file, atlas_1roi, AUC_file, skip_integra
     auc_output = join(testpath, "auc_local.nii.gz")
     subprocess.call(
         "export mode=integration_pfm && "
-        "connPFM -i {} -a {} --AUC {} -d {} -tr 1 -u vferrer -job 0 -nsur 1 -w pfm".format(
+        "connPFM -i {} -a {} --AUC {} -d {} -tr 1 -u vferrer -jobs 0 -nsur 1 -w pfm".format(
             bold_file, atlas_1roi, auc_output, join(testpath, "temp")
         ),
         shell=True,
@@ -50,7 +50,7 @@ def test_integration_ev(
             surr_dir,
             join(dirname(AUC_file), "ets_AUC_denoised.txt"),
         )
-        + "--peaks_points ets_AUC_denoised -tr 1 -u vferrer -nsur 50 -w ev",
+        + "--peaks_points ets_AUC_denoised -tr 1 -u vferrer -jobs 1 -nsur 50 -w ev",
         shell=True,
     )
     ets_auc_denoised_local = np.loadtxt(join(dirname(AUC_file), "ets_AUC_denoised.txt"))


### PR DESCRIPTION
<!---
This is a suggested pull request template for connPFM.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->

The `options["jobs"]` variable is a list when called from the console
Changes proposed in this pull request:

- default should be also a list 
- treat `options["jobs"]` as list when calling ev_workflow so inside it is an integer
