### PR TITLE
Compressed Sparse Row matrix implementation for ETS matrix computations

### DIFF
--- a/connPFM/connectivity/connectivity_utils.py
+++ b/connPFM/connectivity/connectivity_utils.py
@@ -1,8 +1,10 @@
 """Utility functions to perform event detection."""
 import logging
+from termios import CWERASE
 
 import numpy as np
 from scipy.stats import zscore
+from scipy.sparse import csr_matrix
 
 LGR = logging.getLogger(__name__)
 
@@ -11,9 +13,10 @@ def calculate_ets(y, n):
     """Calculate edge-time series."""
     # upper triangle indices (node pairs = edges)
     u, v = np.argwhere(np.triu(np.ones(n), 1)).T
-
+    y_u = csr_matrix(y[:, u])
+    y_v = csr_matrix(y[:, v])
     # edge time series
-    ets = y[:, u] * y[:, v]
+    ets = y_u.multiply(y_v)
 
     return ets, u, v
 

--- a/connPFM/connectivity/connectivity_utils.py
+++ b/connPFM/connectivity/connectivity_utils.py
@@ -1,6 +1,5 @@
 """Utility functions to perform event detection."""
 import logging
-from termios import CWERASE
 
 import numpy as np
 from scipy.sparse import csr_matrix
@@ -55,7 +54,7 @@ def rss_surr(z_ts, u, v, surrprefix, sursufix, masker, irand, nbins, hist_range=
     etsr = zr_u.multiply(zr_v)
 
     # calcuate rss
-    rssr = rss = np.array(np.sqrt(etsr.power(2).sum(axis=1)[:, 0].flatten())).flatten()
+    rssr = np.array(np.sqrt(etsr.power(2).sum(axis=1)[:, 0].flatten())).flatten()
 
     # Calculate histogram
     ets_hist, bin_edges = sparse_histogram(etsr, nbins, hist_range)

--- a/connPFM/connectivity/connectivity_utils.py
+++ b/connPFM/connectivity/connectivity_utils.py
@@ -140,7 +140,7 @@ def calculate_hist(
     """Calculate histogram."""
     ets_temp = calculate_surrogate_ets(surrprefix, sursufix, irand, masker)
     # data works properly for the histogram except for the zero values
-    ets_hist, bin_edges = sparse_histogram(ets_temp.data, nbins, hist_range)
+    ets_hist, bin_edges = sparse_histogram(ets_temp, nbins, hist_range)
 
     return (ets_hist, bin_edges)
 

--- a/connPFM/connectivity/connectivity_utils.py
+++ b/connPFM/connectivity/connectivity_utils.py
@@ -113,7 +113,7 @@ def threshold_ets_matrix(ets_matrix, thr, selected_idxs=None):
         thresholded_matrix = thresholded_matrix - thr_mtx
     else:
         thresholded_matrix -= thr[:, None]
-
+        thresholded_matrix = csr_matrix(thresholded_matrix)
     thresholded_matrix[thresholded_matrix < 0] = 0
     # reconvert so compression is done properly
     thresholded_matrix = csr_matrix(thresholded_matrix.toarray())

--- a/connPFM/connectivity/connectivity_utils.py
+++ b/connPFM/connectivity/connectivity_utils.py
@@ -11,7 +11,7 @@ def sparse_histogram(sparse_matrix, bins, range):
     """Calculate histogram of sparse matrix."""
     hist, bin_edges = np.histogram(sparse_matrix.data, bins=bins, range=range)
     # Correct actual value of zero bin values
-    zeros_in_data = np.sum(sparse_matrix.data==0)
+    zeros_in_data = np.sum(sparse_matrix.data == 0)
     total_e = sparse_matrix.shape[0] * sparse_matrix.shape[1]
     zero_e = total_e - sparse_matrix.count_nonzero() - zeros_in_data
     hist[0] = zero_e + hist[0]

--- a/connPFM/connectivity/connectivity_utils.py
+++ b/connPFM/connectivity/connectivity_utils.py
@@ -104,12 +104,14 @@ def threshold_ets_matrix(ets_matrix, thr, selected_idxs=None):
     # Threshold ETS matrix based on surrogate percentile
     # if thr is not an array, subtract it from the matrix
     if type(thr) is not np.ndarray:
-        thresholded_matrix = thresholded_matrix - thr
+        thr_mtx = csr_matrix(np.ones(thresholded_matrix.shape) * thr)
+        thresholded_matrix = thresholded_matrix - thr_mtx
     else:
         thresholded_matrix -= thr[:, None]
 
     thresholded_matrix[thresholded_matrix < 0] = 0
-
+    # reconvert so compression is done properly
+    thresholded_matrix = csr_matrix(thresholded_matrix.toarray())
     return thresholded_matrix
 
 

--- a/connPFM/connectivity/connectivity_utils.py
+++ b/connPFM/connectivity/connectivity_utils.py
@@ -127,8 +127,12 @@ def calculate_hist(
 ):
     """Calculate histogram."""
     ets_temp = calculate_surrogate_ets(surrprefix, sursufix, irand, masker)
-
-    ets_hist, bin_edges = np.histogram(ets_temp.flatten(), bins=nbins, range=hist_range)
+    # data works properly for the histogram except for the zero values
+    ets_hist, bin_edges = np.histogram(ets_temp.data, bins=nbins, range=hist_range)
+    # Correct actual value of zero bin values
+    total_e = ets_temp.shape[0]*ets_temp.shape[1]
+    zero_e = total_e - ets_temp.count_nonzero()
+    ets_hist[0] = zero_e + ets_hist[0]
 
     return (ets_hist, bin_edges)
 

--- a/connPFM/connectivity/connectivity_utils.py
+++ b/connPFM/connectivity/connectivity_utils.py
@@ -8,6 +8,15 @@ from scipy.sparse import csr_matrix
 
 LGR = logging.getLogger(__name__)
 
+def sparse_histogram(sparse_matrix, bins, range):
+    """Calculate histogram of sparse matrix."""
+    hist, bin_edges = np.histogram(sparse_matrix.data, bins=bins, range=range)
+    # Correct actual value of zero bin values
+    total_e = sparse_matrix.shape[0]*sparse_matrix.shape[1]
+    zero_e = total_e - sparse_matrix.count_nonzero()
+    hist[0] = zero_e + hist[0]
+
+    return hist, bin_edges    
 
 def calculate_ets(y, n):
     """Calculate edge-time series."""
@@ -47,11 +56,7 @@ def rss_surr(z_ts, u, v, surrprefix, sursufix, masker, irand, nbins, hist_range=
     rssr = rss = np.array(np.sqrt(etsr.power(2).sum(axis=1)[:,0].flatten())).flatten()
 
     # Calculate histogram
-    ets_hist, bin_edges = np.histogram(etsr.data, bins=nbins, range=hist_range)
-    # Correct actual value of zero bin values
-    total_e = etsr.shape[0]*etsr.shape[1]
-    zero_e = total_e - etsr.count_nonzero()
-    ets_hist[0] = zero_e + ets_hist[0]
+    ets_hist, bin_edges = sparse_histogram(etsr, nbins, hist_range)
 
     return (rssr, etsr, ets_hist, bin_edges)
 
@@ -135,11 +140,7 @@ def calculate_hist(
     """Calculate histogram."""
     ets_temp = calculate_surrogate_ets(surrprefix, sursufix, irand, masker)
     # data works properly for the histogram except for the zero values
-    ets_hist, bin_edges = np.histogram(ets_temp.data, bins=nbins, range=hist_range)
-    # Correct actual value of zero bin values
-    total_e = ets_temp.shape[0]*ets_temp.shape[1]
-    zero_e = total_e - ets_temp.count_nonzero()
-    ets_hist[0] = zero_e + ets_hist[0]
+    ets_hist, bin_edges = sparse_histogram(ets_temp.data, nbins, hist_range)
 
     return (ets_hist, bin_edges)
 

--- a/connPFM/connectivity/connectivity_utils.py
+++ b/connPFM/connectivity/connectivity_utils.py
@@ -115,7 +115,7 @@ def threshold_ets_matrix(ets_matrix, thr, selected_idxs=None):
         thresholded_matrix = csr_matrix(thresholded_matrix)
     thresholded_matrix[thresholded_matrix < 0] = 0
     # reconvert so compression is done properly
-    thresholded_matrix = csr_matrix(thresholded_matrix.toarray())
+    thresholded_matrix.eliminate_zeros()
     return thresholded_matrix
 
 

--- a/connPFM/connectivity/connectivity_utils.py
+++ b/connPFM/connectivity/connectivity_utils.py
@@ -3,20 +3,22 @@ import logging
 from termios import CWERASE
 
 import numpy as np
-from scipy.stats import zscore
 from scipy.sparse import csr_matrix
+from scipy.stats import zscore
 
 LGR = logging.getLogger(__name__)
+
 
 def sparse_histogram(sparse_matrix, bins, range):
     """Calculate histogram of sparse matrix."""
     hist, bin_edges = np.histogram(sparse_matrix.data, bins=bins, range=range)
     # Correct actual value of zero bin values
-    total_e = sparse_matrix.shape[0]*sparse_matrix.shape[1]
+    total_e = sparse_matrix.shape[0] * sparse_matrix.shape[1]
     zero_e = total_e - sparse_matrix.count_nonzero()
     hist[0] = zero_e + hist[0]
 
-    return hist, bin_edges    
+    return hist, bin_edges
+
 
 def calculate_ets(y, n):
     """Calculate edge-time series."""
@@ -53,7 +55,7 @@ def rss_surr(z_ts, u, v, surrprefix, sursufix, masker, irand, nbins, hist_range=
     etsr = zr_u.multiply(zr_v)
 
     # calcuate rss
-    rssr = rss = np.array(np.sqrt(etsr.power(2).sum(axis=1)[:,0].flatten())).flatten()
+    rssr = rss = np.array(np.sqrt(etsr.power(2).sum(axis=1)[:, 0].flatten())).flatten()
 
     # Calculate histogram
     ets_hist, bin_edges = sparse_histogram(etsr, nbins, hist_range)

--- a/connPFM/connectivity/connectivity_utils.py
+++ b/connPFM/connectivity/connectivity_utils.py
@@ -11,8 +11,9 @@ def sparse_histogram(sparse_matrix, bins, range):
     """Calculate histogram of sparse matrix."""
     hist, bin_edges = np.histogram(sparse_matrix.data, bins=bins, range=range)
     # Correct actual value of zero bin values
+    zeros_in_data = np.sum(sparse_matrix.data==0)
     total_e = sparse_matrix.shape[0] * sparse_matrix.shape[1]
-    zero_e = total_e - sparse_matrix.count_nonzero()
+    zero_e = total_e - sparse_matrix.count_nonzero() - zeros_in_data
     hist[0] = zero_e + hist[0]
 
     return hist, bin_edges

--- a/connPFM/connectivity/ev.py
+++ b/connPFM/connectivity/ev.py
@@ -130,7 +130,8 @@ def event_detection(
                 for sur_idx in range(nsur):
                     sur_ets_at_time[sur_idx, :] = surrogate_events[sur_idx][1][time_idx, :]
 
-                # calculate histogram of all surrogate ets at time point, this is still done without sparse matrix
+                # calculate histogram of all surrogate ets at time point,
+                # this is still done without sparse matrix
                 hist, bins = np.histogram(
                     sur_ets_at_time.toarray().flatten(), bins=nbins, range=(0, 1)
                 )

--- a/connPFM/connectivity/ev.py
+++ b/connPFM/connectivity/ev.py
@@ -4,8 +4,8 @@ from os.path import join
 
 import numpy as np
 from joblib import Parallel, delayed
-from scipy.stats import zscore
 from scipy.sparse import csr_matrix
+from scipy.stats import zscore
 
 from connPFM.connectivity import connectivity_utils
 from connPFM.connectivity.plotting import plot_ets_matrix
@@ -65,7 +65,7 @@ def event_detection(
     if "rss" in peak_detection:
         LGR.info("Selecting points with RSS...")
         # calculate rss
-        rss = np.array(np.sqrt(ets.power(2).sum(axis=1)[:,0].flatten())).flatten()
+        rss = np.array(np.sqrt(ets.power(2).sum(axis=1)[:, 0].flatten())).flatten()
 
         for irand in range(nsur):
             rssr[:, irand] = surrogate_events[irand][0]
@@ -131,7 +131,9 @@ def event_detection(
                     sur_ets_at_time[sur_idx, :] = surrogate_events[sur_idx][1][time_idx, :]
 
                 # calculate histogram of all surrogate ets at time point, this is still done without sparse matrix
-                hist, bins = np.histogram(sur_ets_at_time.toarray().flatten(), bins=nbins, range=(0, 1))
+                hist, bins = np.histogram(
+                    sur_ets_at_time.toarray().flatten(), bins=nbins, range=(0, 1)
+                )
 
                 # calculate threshold for time point
                 thr[time_idx] = connectivity_utils.calculate_hist_threshold(
@@ -140,7 +142,7 @@ def event_detection(
         # Apply threshold on edge time-series matrix
         etspeaks = connectivity_utils.threshold_ets_matrix(ets.copy(), thr)
         idxpeak = etspeaks.nonzero()[0]
-        rss = np.array(np.sqrt(ets.power(2).sum(axis=1)[:,0].flatten())).flatten()
+        rss = np.array(np.sqrt(ets.power(2).sum(axis=1)[:, 0].flatten())).flatten()
     # calculate mean co-fluctuation (edge time series) across all peaks
     mu = np.mean(etspeaks, 0)
 

--- a/connPFM/connectivity/ev.py
+++ b/connPFM/connectivity/ev.py
@@ -192,7 +192,7 @@ def ev_workflow(
 
     LGR.info("Plotting original, AUC, and AUC-denoised ETS matrices...")
     plot_ets_matrix(
-        ets_orig_denoised,
+        ets_orig_denoised.toarray(),
         out_dir,
         rss_orig,
         "_original_" + peak_detection,
@@ -202,7 +202,7 @@ def ev_workflow(
     )
     # Plot ETS and denoised ETS matrices of AUC
     plot_ets_matrix(
-        ets_auc,
+        ets_auc.toarray(),
         out_dir,
         rss_auc,
         "_AUC_original_" + peak_detection,
@@ -211,7 +211,7 @@ def ev_workflow(
         idxpeak_auc,
     )
     plot_ets_matrix(
-        ets_auc_denoised,
+        ets_auc_denoised.toarray(),
         out_dir,
         rss_auc,
         "_AUC_denoised_" + peak_detection,
@@ -236,6 +236,6 @@ def ev_workflow(
         if peak_detection == "ets":
             np.savetxt(join(out_dir, afni_text) + "_rss.txt", rss_auc)
 
-    np.savetxt(matrix, ets_auc_denoised)
+    np.savetxt(matrix, ets_auc_denoised.toarray())
 
     return ets_auc_denoised

--- a/connPFM/connectivity/ev.py
+++ b/connPFM/connectivity/ev.py
@@ -122,6 +122,7 @@ def event_detection(
                 # get first column of all sur_ets into a matrix
                 for sur_idx in range(nsur):
                     sur_ets_at_time[sur_idx, :] = surrogate_events[sur_idx][1][time_idx, :]
+                    sur_ets_at_time.eliminate_zeros()
 
                 # calculate histogram of all surrogate ets at time point,
                 # this is still done without sparse matrix

--- a/connPFM/connectivity/ev.py
+++ b/connPFM/connectivity/ev.py
@@ -130,14 +130,13 @@ def event_detection(
                 for sur_idx in range(nsur):
                     sur_ets_at_time[sur_idx, :] = surrogate_events[sur_idx][1][time_idx, :]
 
-                # calculate histogram of all surrogate ets at time point
-                hist, bins = connectivity_utils.sparse_histogram(sur_ets_at_time, bins=nbins, range=(0, 1))
+                # calculate histogram of all surrogate ets at time point, this is still done without sparse matrix
+                hist, bins = np.histogram(sur_ets_at_time.toarray().flatten(), bins=nbins, range=(0, 1))
 
                 # calculate threshold for time point
                 thr[time_idx] = connectivity_utils.calculate_hist_threshold(
                     hist, bins, percentile=95
                 )
-
         # Apply threshold on edge time-series matrix
         etspeaks = connectivity_utils.threshold_ets_matrix(ets.copy(), thr)
         idxpeak = etspeaks.nonzero()[0]

--- a/connPFM/connectivity/ev.py
+++ b/connPFM/connectivity/ev.py
@@ -125,8 +125,8 @@ def event_detection(
 
                 # calculate histogram of all surrogate ets at time point,
                 # this is still done without sparse matrix
-                hist, bins = np.histogram(
-                    sur_ets_at_time.toarray().flatten(), bins=nbins, range=(0, 1)
+                hist, bins = connectivity_utils.sparse_histogram(
+                    sur_ets_at_time, bins=nbins, range=(0, 1)
                 )
 
                 # calculate threshold for time point

--- a/connPFM/tests/test_ev.py
+++ b/connPFM/tests/test_ev.py
@@ -17,7 +17,7 @@ def test_calculate_ets(ets_auc_original_file, AUC_file, atlas_file):
     AUC_img = masker.fit_transform(AUC_file)
     ets_auc_orig = np.loadtxt(ets_auc_original_file)
     ets_auc_calc, u_vec, v_vec = connectivity_utils.calculate_ets(AUC_img, AUC_img.shape[1])
-    assert np.all(np.isclose(ets_auc_orig, ets_auc_calc))
+    assert np.all(np.isclose(ets_auc_orig, ets_auc_calc.toarray()))
 
 
 def test_rss_surr(AUC_file, atlas_file, surr_dir, rssr_auc_file):
@@ -56,7 +56,7 @@ def test_calculate_surrogate_ets(atlas_file, surr_dir, surrogate_ets_file):
     ets_surr = connectivity_utils.calculate_surrogate_ets(
         surrprefix=join(surr_dir, "surrogate_AUC_"), sursufix="", irand=0, masker=masker
     )
-    assert np.allclose(ets_surr, np.load(surrogate_ets_file))
+    assert np.allclose(ets_surr.toarray(), np.load(surrogate_ets_file))
 
 
 def test_calculate_hist(atlas_file, surr_dir, surrogate_hist_file):

--- a/connPFM/tests/test_ev.py
+++ b/connPFM/tests/test_ev.py
@@ -51,7 +51,9 @@ def test_threshold_ets_matrix():
     dum_mat2 = np.zeros((3, 3))
     dum_mat2[2, 1] = 1
     dum_mat[1, 1] = 1
-    th_dum = connectivity_utils.threshold_ets_matrix(dum_mat, thr=np.array([1,1,2]), selected_idxs=[1,2])
+    th_dum = connectivity_utils.threshold_ets_matrix(
+        dum_mat, thr=np.array([1, 1, 2]), selected_idxs=[1, 2]
+    )
     assert np.allclose(th_dum.toarray(), dum_mat2)
 
 

--- a/connPFM/tests/test_ev.py
+++ b/connPFM/tests/test_ev.py
@@ -43,7 +43,16 @@ def test_threshold_ets_matrix():
     dum_mat2 = np.zeros((3, 3))
     dum_mat2[2, 1] = 1
     th_dum = connectivity_utils.threshold_ets_matrix(dum_mat, thr=2, selected_idxs=2)
-    assert np.allclose(th_dum, dum_mat2)
+    assert np.allclose(th_dum.toarray(), dum_mat2)
+    dum_mat = np.ones((3, 3))
+    dum_mat[1, 1] = 2
+    dum_mat[2, 1] = 3
+    # test for differernt thresholds
+    dum_mat2 = np.zeros((3, 3))
+    dum_mat2[2, 1] = 1
+    dum_mat[1, 1] = 1
+    th_dum = connectivity_utils.threshold_ets_matrix(dum_mat, thr=np.array([1,1,2]), selected_idxs=[1,2])
+    assert np.allclose(th_dum.toarray(), dum_mat2)
 
 
 def test_calculate_surrogate_ets(atlas_file, surr_dir, surrogate_ets_file):
@@ -88,8 +97,8 @@ def test_event_detection_rss(
         peak_detection="rss",
         te=[0],
     )
-    assert np.allclose(ets_rss, np.loadtxt(ets_auc_original_file))
-    assert np.allclose(ets_denoised_rss, np.loadtxt(ets_auc_denoised_file))
+    assert np.allclose(ets_rss.toarray(), np.loadtxt(ets_auc_original_file))
+    assert np.allclose(ets_denoised_rss.toarray(), np.loadtxt(ets_auc_denoised_file))
 
 
 def test_event_detection_rss_time(
@@ -104,9 +113,8 @@ def test_event_detection_rss_time(
         peak_detection="rss_time",
         te=[0],
     )
-
-    assert np.allclose(ets_rss_time, np.load(ets_auc_all)[:, :, 1])
-    assert np.allclose(ets_denoised_rss_time, np.load(ets_auc_denoised_all)[:, :, 1])
+    assert np.allclose(ets_rss_time.toarray(), np.load(ets_auc_all)[:, :, 1])
+    assert np.allclose(ets_denoised_rss_time.toarray(), np.load(ets_auc_denoised_all)[:, :, 1])
 
 
 def test_event_detection_ets(AUC_file, atlas_file, surr_dir, ets_auc_all, ets_auc_denoised_all):
@@ -120,8 +128,8 @@ def test_event_detection_ets(AUC_file, atlas_file, surr_dir, ets_auc_all, ets_au
         te=[0],
     )
 
-    assert np.allclose(ets, np.load(ets_auc_all)[:, :, 2])
-    assert np.allclose(ets_denoised, np.load(ets_auc_denoised_all)[:, :, 2])
+    assert np.allclose(ets.toarray(), np.load(ets_auc_all)[:, :, 2])
+    assert np.allclose(ets_denoised.toarray(), np.load(ets_auc_denoised_all)[:, :, 2])
 
 
 def test_event_detection_ets_time(
@@ -136,9 +144,8 @@ def test_event_detection_ets_time(
         peak_detection="ets_time",
         te=[0],
     )
-
-    assert np.allclose(ets_time, np.load(ets_auc_all)[:, :, 3])
-    assert np.allclose(ets_denoised_time, np.load(ets_auc_denoised_all)[:, :, 3])
+    assert np.allclose(ets_time.toarray(), np.load(ets_auc_all)[:, :, 3])
+    assert np.allclose(ets_denoised_time.toarray(), np.load(ets_auc_denoised_all)[:, :, 3])
 
 
 def test_plotting(testpath, ets_auc_denoised_all):


### PR DESCRIPTION
<!---
This is a suggested pull request template for connPFM.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #93  .

As said in #93, `ETS_AUC` matrices have 87% sparsity. Therefore we can use the `scipy.sparse` module to decrease the amount of bytes  required to keep them in memory. This should let us increase the amount of ROIs that we can have in an atlas. 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Use the sparse matrices as much as possible in the code
- sparse_histogram function: ETS matrix histogram is computed from the sparse data and then the `0` bin count is corrected adding the zero values that are not in `spare_matrix.data` vector.
- Full implementation in the threshold calculation process and the matrix threshold process
- Should we save the ETS matrices in sparse or leave it as `.txt`?
