### PR TITLE
calculate all histograms in parallel so we don't have to keep the surrogates ets matrices in `even_detection`

### DIFF
--- a/connPFM/connectivity/connectivity_utils.py
+++ b/connPFM/connectivity/connectivity_utils.py
@@ -57,7 +57,12 @@ def rss_surr(z_ts, u, v, surrprefix, sursufix, masker, irand, nbins, hist_range=
     # Calculate histogram
     ets_hist, bin_edges = sparse_histogram(etsr, nbins, hist_range)
 
-    return (rssr, etsr, ets_hist, bin_edges)
+    # calculate histogram for each timepoint
+    ets_hist_time = np.zeros((t,nbins))
+    for time in range(t):
+        ets_hist_time = sparse_histogram(etsr[time,:], nbins, hist_range)
+
+    return (rssr, ets_hist,ets_hist_time, bin_edges)
 
 
 def remove_neighboring_peaks(rss, idx):
@@ -164,7 +169,7 @@ def sum_histograms(
     all_hists = np.zeros((len(hist_list), hist_list[0][3].shape[0] - 1))
 
     for rand_idx in range(len(hist_list)):
-        all_hists[rand_idx, :] = hist_list[rand_idx][2]
+        all_hists[rand_idx, :] = hist_list[rand_idx][1]
 
     ets_hist_sum = np.sum(all_hists, axis=0)
 

--- a/connPFM/connectivity/ev.py
+++ b/connPFM/connectivity/ev.py
@@ -116,19 +116,17 @@ def event_detection(
             thr = np.zeros(t)
 
             # initialize array for surrogate ets at each time point
-            sur_ets_at_time = csr_matrix(np.zeros((nsur, surrogate_events[0][1].shape[1])))
+            hist_time_surrogates = np.zeros([ nsur, t, nbins])
+            for sur_idx in range(nsur):
+                hist_time_surrogates[sur_idx, :,:] = surrogate_events[sur_idx][2]
+            
+
 
             for time_idx in range(t):
                 # get first column of all sur_ets into a matrix
-                for sur_idx in range(nsur):
-                    sur_ets_at_time[sur_idx, :] = surrogate_events[sur_idx][1][time_idx, :]
-                    sur_ets_at_time.eliminate_zeros()
-
                 # calculate histogram of all surrogate ets at time point,
                 # this is still done without sparse matrix
-                hist, bins = connectivity_utils.sparse_histogram(
-                    sur_ets_at_time, bins=nbins, range=(0, 1)
-                )
+                hist = np.sum(hist_time_surrogates[:,time_idx,:],axis=0)
 
                 # calculate threshold for time point
                 thr[time_idx] = connectivity_utils.calculate_hist_threshold(


### PR DESCRIPTION
<!---
This is a suggested pull request template for connPFM.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-
